### PR TITLE
handle status code from api.mojang.com

### DIFF
--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -3,6 +3,7 @@ package exporter
 import (
 	"compress/gzip"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -612,6 +613,10 @@ func (e *Exporter) getPlayerStats(ch chan<- prometheus.Metric) error {
 		resp, err := http.Get(URL)
 		if err != nil {
 			level.Error(e.logger).Log("msg", "Failed to connect to api.mojang.com", "err", err)
+		}
+
+		if resp.StatusCode != 200 {
+			return fmt.Errorf("error retrieving player info from api.mojang.com: %w", errors.New(fmt.Sprintf("Status Code: %d", resp.StatusCode)))
 		}
 
 		var cResp []Player


### PR DESCRIPTION
Happens to be not 200, if eg. Cloudflare blocks the traffic:

```html
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
<HTML><HEAD><META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=iso-8859-1">
<TITLE>ERROR: The request could not be satisfied</TITLE>
</HEAD><BODY>
<H1>403 ERROR</H1>
<H2>The request could not be satisfied.</H2>
<HR noshade size="1px">
Request blocked.
We can't connect to the server for this app or website at this time. There might be too much traffic or a configuration error. Try again later, or contact the app or website owner.
<BR clear="all">
If you provide content to customers through CloudFront, you can find steps to troubleshoot and help prevent this error by reviewing the CloudFront documentation.
<BR clear="all">
<HR noshade size="1px">
<PRE>
Generated by cloudfront (CloudFront)
Request ID: M7Uo1IsOPylDr8slCc5qWbhO4EhfV0xRpjG2d48VQzkNCVrjt0TnEQ==
</PRE>
<ADDRESS>
</ADDRESS>
* Connection #0 to host api.mojang.com left intact
</BODY></HTML>
```

Signed-off-by: Engin Diri <engin.diri@mail.schwarz>