### PR TITLE
Improve name lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ usage: minecraft-prometheus-exporter [<flags>]
 Flags:
   -h, --help                     Show context-sensitive help (also try --help-long and --help-man).
       --web.config.file=""       [EXPERIMENTAL] Path to configuration file that can enable TLS or authentication.
-      --config-path="config.yml"
-                                 Path to YAML file with config.
       --web.listen-address=":9150"
                                  Address to listen on for web interface and telemetry.
+      --mc.config-path="config.yml"
+                                 Path to YAML file with config.
       --mc.world="/minecraft/world"
                                  Path the to world folder
       --mc.rcon-address=":25575"
@@ -80,7 +80,6 @@ Flags:
                                  Path under which to expose metrics.
       --log.level=info           Only log messages with the given severity or above. One of: [debug, info, warn, error]
       --log.format=logfmt        Output format of log messages. One of: [logfmt, json]
-      --version                  Show application version.
 ```
 
 ### Config 🔧

--- a/README.md
+++ b/README.md
@@ -63,23 +63,54 @@ Details for the specific stats can be found here -> https://minecraft.fandom.com
 usage: minecraft-prometheus-exporter [<flags>]
 
 Flags:
-  -h, --help                Show context-sensitive help (also try --help-long and --help-man).
-      --web.config.file=""  [EXPERIMENTAL] Path to configuration file that can enable TLS or authentication.
+  -h, --help                     Show context-sensitive help (also try --help-long and --help-man).
+      --web.config.file=""       [EXPERIMENTAL] Path to configuration file that can enable TLS or authentication.
+      --config-path="config.yml"
+                                 Path to YAML file with config.
       --web.listen-address=":9150"
-                            Address to listen on for web interface and telemetry.
+                                 Address to listen on for web interface and telemetry.
       --mc.world="/minecraft/world"
-                            Path the to world folder
+                                 Path the to world folder
       --mc.rcon-address=":25575"
-                            Address of the Minecraft rcon.
+                                 Address of the Minecraft rcon.
       --mc.rcon-password=MC.RCON-PASSWORD
-                            Password of the Minecraft rcon.
-      --mc.name-source=MC.NAME-SOURCE
-                            How to retrieve names of players: offline, bukkit, mojang
+                                 Password of the Minecraft rcon.
+      --mc.name-source="mojang"  How to retrieve names of players: offline, bukkit, mojang.
       --web.telemetry-path="/metrics"
-                            Path under which to expose metrics.
-      --log.level=info      Only log messages with the given severity or above. One of: [debug, info, warn, error]
-      --log.format=logfmt   Output format of log messages. One of: [logfmt, json]
-      --version             Show application version.
+                                 Path under which to expose metrics.
+      --log.level=info           Only log messages with the given severity or above. One of: [debug, info, warn, error]
+      --log.format=logfmt        Output format of log messages. One of: [logfmt, json]
+      --version                  Show application version.
+```
+
+### Config 🔧
+You can override CLI flags using config file. By default, `config.yml` located in the current directory is used.
+Path to config file can be changed using `--config-path` CLI flag.
+
+| Key in config file | Equivalent CLI flag    | Description                                                                      |
+| ---                | ---                    | ---                                                                              |
+| `metrics-path`     | `--web.telemetry-path` | Path under which to expose metrics.                                              |
+| `web-config`       | `--web.config.file`    | **[EXPERIMENTAL]** Path to configuration file that can enable TLS or authentication. |
+| `listen-address`   | `--web.listen-address` | Address to listen on for web interface and telemetry.                            |
+| `world-path`       | `--mc.world`           | Path the to world folder.                                                        |
+| `rcon-address`     | `--mc.rcon-address`    | Address of the Minecraft rcon.                                                   |
+| `rcon-password`    | `--mc.rcon-password`   | Password of the Minecraft rcon.                                                  |
+| `name-source`      | `--mc.name-source`     | How to retrieve names of players: offline, bukkit, mojang.                       |
+| `disabled-metrics` | -                      | Namespaced keys that used by metrics that should be disabled.                    |
+
+#### Disabling metrics
+
+To disable certain metrics, just add corresponding key to `disabled-metrics` section with `true` value in your config file.
+You should use keys that used by Minecraft to store players' stats.
+
+#### Example config
+
+```yaml
+disabled-metrics:
+  minecraft:mined: true # Disable "minecraft_prometheus_exporter_blocks_mined_total" metric
+  minecraft:creeper: true # Disable all metrics related with creepers
+  minecraft:custom: false # "false" values will be ignored, so this line does nothing
+listen-address: ':9151' # Change address of web server. "--web.listen-address" will be ignored if this line is present here
 ```
 
 ### Collectors 📊

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Flags:
                                  Path under which to expose metrics.
       --log.level=info           Only log messages with the given severity or above. One of: [debug, info, warn, error]
       --log.format=logfmt        Output format of log messages. One of: [logfmt, json]
+      --version                  Show application version.
 ```
 
 ### Config 🔧

--- a/README.md
+++ b/README.md
@@ -65,15 +65,17 @@ usage: minecraft-prometheus-exporter [<flags>]
 Flags:
   -h, --help                Show context-sensitive help (also try --help-long and --help-man).
       --web.config.file=""  [EXPERIMENTAL] Path to configuration file that can enable TLS or authentication.
-      --web.listen-address=":9150"  
+      --web.listen-address=":9150"
                             Address to listen on for web interface and telemetry.
-      --mc.world="/minecraft/world"  
+      --mc.world="/minecraft/world"
                             Path the to world folder
-      --mc.rcon-address=":25575"  
+      --mc.rcon-address=":25575"
                             Address of the Minecraft rcon.
-      --mc.rcon-password=MC.RCON-PASSWORD  
+      --mc.rcon-password=MC.RCON-PASSWORD
                             Password of the Minecraft rcon.
-      --web.telemetry-path="/metrics"  
+      --mc.name-source=MC.NAME-SOURCE
+                            How to retrieve names of players: offline, bukkit, mojang
+      --web.telemetry-path="/metrics"
                             Path under which to expose metrics.
       --log.level=info      Only log messages with the given severity or above. One of: [debug, info, warn, error]
       --log.format=logfmt   Output format of log messages. One of: [logfmt, json]

--- a/cmd/minecraft-prometheus-exporter/main.go
+++ b/cmd/minecraft-prometheus-exporter/main.go
@@ -32,7 +32,7 @@ func Run() {
 	level.Info(logger).Log("msg", "Build context", "build", version.BuildContext())
 
 	prometheus.MustRegister(version.NewCollector("minecraft_prometheus_exporter"))
-	prometheus.MustRegister(exporter.New(*config.RconAddress, *config.RconPassword, *config.WorldPath, logger))
+	prometheus.MustRegister(exporter.New(*config.RconAddress, *config.RconPassword, *config.WorldPath, *config.NameSource, logger))
 
 	http.Handle(*config.MetricsPath, promhttp.Handler())
 	template := template.NewIndexTemplate()

--- a/cmd/minecraft-prometheus-exporter/main.go
+++ b/cmd/minecraft-prometheus-exporter/main.go
@@ -28,11 +28,13 @@ func Run() {
 	kingpin.Parse()
 	logger := promlog.New(promlogConfig)
 
+	config.LoadFile()
+
 	level.Info(logger).Log("msg", "Starting minecraft_prometheus_exporter", "version", version.Info())
 	level.Info(logger).Log("msg", "Build context", "build", version.BuildContext())
 
 	prometheus.MustRegister(version.NewCollector("minecraft_prometheus_exporter"))
-	prometheus.MustRegister(exporter.New(*config.RconAddress, *config.RconPassword, *config.WorldPath, *config.NameSource, logger))
+	prometheus.MustRegister(exporter.New(*config.RconAddress, *config.RconPassword, *config.WorldPath, *config.NameSource, config.DisabledMetrics, logger))
 
 	http.Handle(*config.MetricsPath, promhttp.Handler())
 	template := template.NewIndexTemplate()

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,5 @@ require (
 	github.com/prometheus/common v0.29.0
 	github.com/prometheus/exporter-toolkit v0.6.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
+	gopkg.in/yaml.v2 v2.4.0
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,8 +25,8 @@ type Config struct {
 func NewConfg() *Config {
 	var (
 		webConfig     = webflag.AddFlags(kingpin.CommandLine)
-		configPath    = kingpin.Flag("config-path", "Path to YAML file with config.").Default("config.yml").String()
 		listenAddress = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9150").String()
+		configPath    = kingpin.Flag("mc.config-path", "Path to YAML file with config.").Default("config.yml").String()
 		worldPath     = kingpin.Flag("mc.world", "Path the to world folder").Default("/minecraft/world").String()
 		rconAddress   = kingpin.Flag("mc.rcon-address", "Address of the Minecraft rcon.").Default(":25575").String()
 		rconPassword  = kingpin.Flag("mc.rcon-password", "Password of the Minecraft rcon.").String()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Config struct {
-	ConfigPath      *string         `yaml:"config-path"`
+	ConfigPath      *string
 	MetricsPath     *string         `yaml:"metrics-path"`
 	WebConfig       *string         `yaml:"web-config"`
 	ListenAddress   *string         `yaml:"listen-address"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	WorldPath     *string
 	RconAddress   *string
 	RconPassword  *string
+	NameSource    *string
 }
 
 func NewConfg() *Config {
@@ -21,6 +22,7 @@ func NewConfg() *Config {
 		worldPath     = kingpin.Flag("mc.world", "Path the to world folder").Default("/minecraft/world").String()
 		rconAddress   = kingpin.Flag("mc.rcon-address", "Address of the Minecraft rcon.").Default(":25575").String()
 		rconPassword  = kingpin.Flag("mc.rcon-password", "Password of the Minecraft rcon.").String()
+		nameSource    = kingpin.Flag("mc.name-source", "How to retrieve names of players: offline, bukkit, mojang").Default("mojang").String()
 		metricsPath   = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
 	)
 	return &Config{
@@ -30,5 +32,6 @@ func NewConfg() *Config {
 		RconAddress:   rconAddress,
 		RconPassword:  rconPassword,
 		WorldPath:     worldPath,
+		NameSource:    nameSource,
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,31 +1,40 @@
 package config
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
 	webflag "github.com/prometheus/exporter-toolkit/web/kingpinflag"
 	"gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/yaml.v2"
 )
 
 type Config struct {
-	MetricsPath   *string
-	WebConfig     *string
-	ListenAddress *string
-	WorldPath     *string
-	RconAddress   *string
-	RconPassword  *string
-	NameSource    *string
+	ConfigPath      *string         `yaml:"config-path"`
+	MetricsPath     *string         `yaml:"metrics-path"`
+	WebConfig       *string         `yaml:"web-config"`
+	ListenAddress   *string         `yaml:"listen-address"`
+	WorldPath       *string         `yaml:"world-path"`
+	RconAddress     *string         `yaml:"rcon-address"`
+	RconPassword    *string         `yaml:"rcon-password"`
+	NameSource      *string         `yaml:"name-source"`
+	DisabledMetrics map[string]bool `yaml:"disabled-metrics"`
 }
 
 func NewConfg() *Config {
 	var (
 		webConfig     = webflag.AddFlags(kingpin.CommandLine)
+		configPath    = kingpin.Flag("config-path", "Path to YAML file with config.").Default("config.yml").String()
 		listenAddress = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9150").String()
 		worldPath     = kingpin.Flag("mc.world", "Path the to world folder").Default("/minecraft/world").String()
 		rconAddress   = kingpin.Flag("mc.rcon-address", "Address of the Minecraft rcon.").Default(":25575").String()
 		rconPassword  = kingpin.Flag("mc.rcon-password", "Password of the Minecraft rcon.").String()
-		nameSource    = kingpin.Flag("mc.name-source", "How to retrieve names of players: offline, bukkit, mojang").Default("mojang").String()
+		nameSource    = kingpin.Flag("mc.name-source", "How to retrieve names of players: offline, bukkit, mojang.").Default("mojang").String()
 		metricsPath   = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
 	)
 	return &Config{
+		ConfigPath:    configPath,
 		MetricsPath:   metricsPath,
 		WebConfig:     webConfig,
 		ListenAddress: listenAddress,
@@ -33,5 +42,29 @@ func NewConfg() *Config {
 		RconPassword:  rconPassword,
 		WorldPath:     worldPath,
 		NameSource:    nameSource,
+	}
+}
+
+func (c *Config) LoadFile() {
+	path, err := filepath.Abs(*c.ConfigPath)
+	if err != nil {
+		return
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return
+	}
+
+	defer f.Close()
+
+	bytes, err := ioutil.ReadAll(f)
+	if err != nil {
+		return
+	}
+
+	err = yaml.Unmarshal(bytes, c)
+	if err != nil {
+		return
 	}
 }


### PR DESCRIPTION
To learn the name of the player, exporter just creates a request to Mojang API. There are at least 2 disadvantages of this solution:
1. What if I have a server with 1000 registered players? Yes, it just makes 1000 requests to Mojang API. Just 1000 HTTP requests.
2. Cracked servers are not supported. So, some countries like Russia, where cracked servers are popular, are not supported too.

I've implemented a `--mc.name-source` flag that allows to change behavior when looking up for player name. Supported values are `mojang` and `bukkit`. 
* If set to `mojang`, it will make request to Mojang API for each player. 
* If set to `bukkit`, name will be fetched from `lastKnownName` NBT tag that added by Bukkit. 
* If `offline` or any other value is set, it will use UUID as name.