### PR TITLE
Fix cyclic files breaking player stats

### DIFF
--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -444,7 +444,7 @@ func (e *Exporter) getPlayerStats(ch chan<- prometheus.Metric) error {
 		return err
 	}
 	for _, file := range files {
-		if filepath.Ext(file.Name()) == ".dat" {
+		if filepath.Ext(file.Name()) == ".dat" && !strings.Contains(file.Name(), "_cyclic") {
 			id := strings.TrimSuffix(file.Name(), ".dat")
 			f, err := os.Open(e.world + "/playerdata/" + file.Name())
 			if err != nil {


### PR DESCRIPTION
Currently, the Mojang stats request fails because of files ending in _cylic.dat being present in the playerdata directory, which results in all stat requests after encountering such a file never happening.

This checks for those files and ignores them, allowing the exporter to fetch stats properly.

* [x] Read the [contributions](../CONTRIBUTING.md) page.
* [x] Read the [DCO](../DCO), if you are a first time contributor.
* [x] Read the [code of conduct]([Code of Conduct](https://github.com/dirien/.github/blob/main/CODE_OF_CONDUCT.md)).