### PR TITLE
[main] adds fabric support

### DIFF
--- a/CONTAINER.md
+++ b/CONTAINER.md
@@ -55,7 +55,7 @@ You could use the flags too, but I would not recommend it. I prefer to use the e
 | MC_RCON_ADDRESS               | Address for the Minecraft RCON.                            |
 | MC_RCON_PASSWORD              | Password for the Minecraft RCON.                           |
 | MC_NAME_SOURCE                | How to retrieve names of players: offline, bukkit, mojang. |
-| MC_MOD_SERVER_STATS           | Additional server stats for papermc or forge               |
+| MC_MOD_SERVER_STATS           | Additional server stats for papermc, forge, and fabric     |
 
 ### Legal Disclaimer 👮
 

--- a/README.md
+++ b/README.md
@@ -443,6 +443,8 @@ minecraft_won_raids_total{player="ediri"} 0
 To export the metrics for a specific mod, you can set the flag: `--mc.mod-server-stats=forge|papermc|fabric` or use the
 environment variable `MC_MOD_SERVER_STATS`.
 
+**Note:** Fabric requires the [Fabric TPS](https://modrinth.com/mod/fabric-tps) mod.
+
 #### Forge
 
 `minecraft-exporter` exports mean TPS and mean tick time for every dimension and of course the overall mean TPS and mean

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Flags:
                                  Password of the Minecraft rcon.
       --mc.name-source="mojang"  How to retrieve names of players: offline, bukkit, mojang.
       --mc.mod-server-stats=MC.MOD-SERVER-STATS  
-                                 Additional server stats for papermc, purpurmc or forge
+                                 Additional server stats for papermc, purpurmc, forge, or fabric.
       --log.level=info           Only log messages with the given severity or above. One of: [debug, info, warn, error]
       --log.format=logfmt        Output format of log messages. One of: [logfmt, json]
       --version                  Show application version.
@@ -162,17 +162,17 @@ Flags:
 You can override CLI flags using config file. By default, `config.yml` located in the current directory is used. Path to
 config file can be changed using `--config-path` CLI flag.
 
-| Key in config file         | Equivalent CLI flag              | ENV variable                  | Description                                                  |
-|----------------------------|----------------------------------|-------------------------------|--------------------------------------------------------------|
-| `metrics-path`             | `--web.telemetry-path`           | WEB_TELEMETRY_PATH            | Path under which to expose metrics.                          |
-| `listen-address`           | `--web.listen-address`           | WEB_LISTEN_ADDRESS            | Address to listen on for web interface and telemetry.        |
-| `disable-exporter-metrics` | `--web.disable-exporter-metrics` | WEB_DISABLED_EXPORTER_METRICS | Disabling collection of exporter metrics (like go_*)         |
-| `web-config`               | `--mc.config-path`               | MC_CONFIG_PATH                | Path to YAML file with config for the mc variables           |
-| `world-path`               | `--mc.world`                     | MC_WORLD                      | Path to the world folder.                                    |
-| `rcon-address`             | `--mc.rcon-address`              | MC_RCON_ADDRESS               | Address for the Minecraft RCON.                              |
-| `rcon-password`            | `--mc.rcon-password`             | MC_RCON_PASSWORD              | Password for the Minecraft RCON.                             |
-| `name-source`              | `--mc.name-source`               | MC_NAME_SOURCE                | How to retrieve names of players: offline, bukkit, mojang.   |
-| `mod-server-stats`         | `--mc.mod-server-stats`          | MC_MOD_SERVER_STATS           | Set server for additional stats (papermc, purpurmc or forge) |
+| Key in config file         | Equivalent CLI flag              | ENV variable                  | Description                                                           |
+|----------------------------|----------------------------------|-------------------------------|-----------------------------------------------------------------------|
+| `metrics-path`             | `--web.telemetry-path`           | WEB_TELEMETRY_PATH            | Path under which to expose metrics.                                   |
+| `listen-address`           | `--web.listen-address`           | WEB_LISTEN_ADDRESS            | Address to listen on for web interface and telemetry.                 |
+| `disable-exporter-metrics` | `--web.disable-exporter-metrics` | WEB_DISABLED_EXPORTER_METRICS | Disabling collection of exporter metrics (like go_*)                  |
+| `web-config`               | `--mc.config-path`               | MC_CONFIG_PATH                | Path to YAML file with config for the mc variables                    |
+| `world-path`               | `--mc.world`                     | MC_WORLD                      | Path to the world folder.                                             |
+| `rcon-address`             | `--mc.rcon-address`              | MC_RCON_ADDRESS               | Address for the Minecraft RCON.                                       |
+| `rcon-password`            | `--mc.rcon-password`             | MC_RCON_PASSWORD              | Password for the Minecraft RCON.                                      |
+| `name-source`              | `--mc.name-source`               | MC_NAME_SOURCE                | How to retrieve names of players: offline, bukkit, mojang.            |
+| `mod-server-stats`         | `--mc.mod-server-stats`          | MC_MOD_SERVER_STATS           | Set server for additional stats (papermc, purpurmc, forge, or fabric) |
 
 #### Disable exporter metrics
 
@@ -440,7 +440,7 @@ minecraft_won_raids_total{player="ediri"} 0
 
 #### Metrics for specific mods
 
-To export the metrics for a specific mod, you can set the flag: `--mc.mod-server-stats=forge|papermc` or use the
+To export the metrics for a specific mod, you can set the flag: `--mc.mod-server-stats=forge|papermc|fabric` or use the
 environment variable `MC_MOD_SERVER_STATS`.
 
 #### Forge

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,7 +34,7 @@ func NewConfg() *Config {
 		rconAddress             = kingpin.Flag("mc.rcon-address", "Address of the Minecraft rcon.").Envar("MC_RCON_ADDRESS").Default(":25575").String()
 		rconPassword            = kingpin.Flag("mc.rcon-password", "Password of the Minecraft rcon.").Envar("MC_RCON_PASSWORD").String()
 		nameSource              = kingpin.Flag("mc.name-source", "How to retrieve names of players: offline, bukkit, mojang.").Envar("MC_NAME_SOURCE").Default("mojang").String()
-		modServerStats          = kingpin.Flag("mc.mod-server-stats", "Set server for additional stats (papermc, purpurmc or forge)").Envar("MC_MOD_SERVER_STATS").String()
+		modServerStats          = kingpin.Flag("mc.mod-server-stats", "Set server for additional stats (papermc, purpurmc, forge, or fabric)").Envar("MC_MOD_SERVER_STATS").String()
 	)
 	return &Config{
 		ConfigPath:             configPath,


### PR DESCRIPTION
Please reference the issue this PR is fixing.
#957 

Tested:
![image](https://github.com/dirien/minecraft-prometheus-exporter/assets/9059161/decea77f-f6ae-4342-b564-2f5433fefcda)
```
# TYPE minecraft_dimension_ticktime_total counter
minecraft_dimension_ticktime_total{dimension="black_bridge",namespace="minecells"} 0.009
minecraft_dimension_ticktime_total{dimension="earth_orbit",namespace="ad_astra"} 0.009
minecraft_dimension_ticktime_total{dimension="glacio",namespace="ad_astra"} 0.008
minecraft_dimension_ticktime_total{dimension="glacio_orbit",namespace="ad_astra"} 0.009
minecraft_dimension_ticktime_total{dimension="glassocean",namespace="spellbladenext"} 0.01
minecraft_dimension_ticktime_total{dimension="insufferable_crypt",namespace="minecells"} 0.009
minecraft_dimension_ticktime_total{dimension="mars",namespace="ad_astra"} 0.009
minecraft_dimension_ticktime_total{dimension="mars_orbit",namespace="ad_astra"} 0.008
minecraft_dimension_ticktime_total{dimension="mercury",namespace="ad_astra"} 0.008
minecraft_dimension_ticktime_total{dimension="mercury_orbit",namespace="ad_astra"} 0.008
minecraft_dimension_ticktime_total{dimension="moon",namespace="ad_astra"} 0.008
minecraft_dimension_ticktime_total{dimension="moon_orbit",namespace="ad_astra"} 0.008
minecraft_dimension_ticktime_total{dimension="otherside",namespace="deeperdarker"} 0.011
minecraft_dimension_ticktime_total{dimension="overworld",namespace="minecraft"} 8.436
minecraft_dimension_ticktime_total{dimension="prison",namespace="minecells"} 0.008
minecraft_dimension_ticktime_total{dimension="promenade",namespace="minecells"} 0.008
minecraft_dimension_ticktime_total{dimension="ramparts",namespace="minecells"} 0.011
minecraft_dimension_ticktime_total{dimension="spatial_storage",namespace="ae2"} 0.008
minecraft_dimension_ticktime_total{dimension="the_bumblezone",namespace="the_bumblezone"} 0.01
minecraft_dimension_ticktime_total{dimension="the_end",namespace="minecraft"} 0.009
minecraft_dimension_ticktime_total{dimension="the_nether",namespace="minecraft"} 0.013
minecraft_dimension_ticktime_total{dimension="venus",namespace="ad_astra"} 0.008
minecraft_dimension_ticktime_total{dimension="venus_orbit",namespace="ad_astra"} 0.028
# TYPE minecraft_dimension_tps_total counter
minecraft_dimension_tps_total{dimension="black_bridge",namespace="minecells"} 20
minecraft_dimension_tps_total{dimension="earth_orbit",namespace="ad_astra"} 20
minecraft_dimension_tps_total{dimension="glacio",namespace="ad_astra"} 20
minecraft_dimension_tps_total{dimension="glacio_orbit",namespace="ad_astra"} 20
minecraft_dimension_tps_total{dimension="glassocean",namespace="spellbladenext"} 20
minecraft_dimension_tps_total{dimension="insufferable_crypt",namespace="minecells"} 20
minecraft_dimension_tps_total{dimension="mars",namespace="ad_astra"} 20
minecraft_dimension_tps_total{dimension="mars_orbit",namespace="ad_astra"} 20
minecraft_dimension_tps_total{dimension="mercury",namespace="ad_astra"} 20
minecraft_dimension_tps_total{dimension="mercury_orbit",namespace="ad_astra"} 20
minecraft_dimension_tps_total{dimension="moon",namespace="ad_astra"} 20
minecraft_dimension_tps_total{dimension="moon_orbit",namespace="ad_astra"} 20
minecraft_dimension_tps_total{dimension="otherside",namespace="deeperdarker"} 20
minecraft_dimension_tps_total{dimension="overworld",namespace="minecraft"} 20
minecraft_dimension_tps_total{dimension="prison",namespace="minecells"} 20
minecraft_dimension_tps_total{dimension="promenade",namespace="minecells"} 20
minecraft_dimension_tps_total{dimension="ramparts",namespace="minecells"} 20
minecraft_dimension_tps_total{dimension="spatial_storage",namespace="ae2"} 20
minecraft_dimension_tps_total{dimension="the_bumblezone",namespace="the_bumblezone"} 20
minecraft_dimension_tps_total{dimension="the_end",namespace="minecraft"} 20
minecraft_dimension_tps_total{dimension="the_nether",namespace="minecraft"} 20
minecraft_dimension_tps_total{dimension="venus",namespace="ad_astra"} 20
minecraft_dimension_tps_total{dimension="venus_orbit",namespace="ad_astra"} 20
```

On Prominence II.

Note: It requires the [Fabric TPS](https://modrinth.com/mod/fabric-tps) mod (No affiliation), as there is no native TPS method. 
While this pack has spark built in, it's still not ideal.

The nice thing about the Fabric TPS mod is it outputs the same format as `/forge tps` which allows us to reuse that code block. 

Unfortunately, there is no way to easily capture entities. 
I had tried using something like `execute as @e run say @s` which puts out a list like:
```
Bee
Mimic
Mimic
[Minecart with TNT]: Minecart with TNT
Bluejay
Drake
Drake
[Amethyst Golem]: Amethyst Golem
Drake
Drake
Painting
Mimic
Wolf
Wolf
Mimic
Glare
Glare
Glare
Glare
Duck
Duck
Duck
Glare
[Minecart with Chest]: Minecart with Chest
[Minecart with Chest]: Minecart with Chest
[Minecart with Chest]: Minecart with Chest
Drake
[Frozen Flower]: Frozen Flower
[Minecart with Chest]: Minecart with Chest
[Giant Geckotoa]: Giant Geckotoa
[Minecart with Chest]: Minecart with Chest
[Brown Mushroom]: Brown Mushroom
Lizard
Mimic
Mimic
Mimic
[Amethyst Golem]: Amethyst Golem
Rabbit
[Minecart with Chest]: Minecart with Chest
Bluejay
```
By looping through the output. However, this not only logs to the users in-game; but also the rcon plugin doesn't get a response; it's an empty string. So we can't do much with that. 

*Also verify you have:*

* [x] Read the [contributions](../CONTRIBUTING.md) page.
* [x] Read the [DCO](../DCO), if you are a first time contributor.
* [x] Read the [code of conduct]([Code of Conduct](https://github.com/dirien/.github/blob/main/CODE_OF_CONDUCT.md)).