### PR TITLE
docs: fix broken GitHub workflow status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/minecraft-exporter&style=for-the-badge)](https://artifacthub.io/packages/search?repo=minecraft-exporter)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/minecraft-exporter-image&style=for-the-badge)](https://artifacthub.io/packages/search?repo=minecraft-exporter-image)
 
-![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/dirien/minecraft-prometheus-exporter/Build%20Binary/main?logo=github&style=for-the-badge)
+![GitHub Workflow Status (branch)](https://img.shields.io/github/actions/workflow/status/dirien/minecraft-prometheus-exporter/ci.yaml?branch=main&logo=github&style=for-the-badge)
 ![GitHub](https://img.shields.io/github/license/dirien/minecraft-prometheus-exporter?style=for-the-badge)
 
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/dirien/minecraft-prometheus-exporter?style=for-the-badge)


### PR DESCRIPTION
## What

The README's **GitHub Workflow Status** badge rendered as an error badge linking to shields.io issue #8671 instead of the build status.

## Why

The badge used shields.io's deprecated `github/workflow/status` route. That route was backed by a GitHub API endpoint that has been removed, so shields.io now returns the "see issue 8671" error badge for every request to it. The old URL also referenced a stale workflow display name (`Build Binary`), whereas the workflow is named `build-binary` in `ci.yaml`.

## Change

Switched to the current `github/actions/workflow/status` route, which takes the workflow **filename** (`ci.yaml`) and the branch as a query param:

\`\`\`
https://img.shields.io/github/actions/workflow/status/dirien/minecraft-prometheus-exporter/ci.yaml?branch=main&logo=github&style=for-the-badge
\`\`\`

Verified the new URL returns \`build: passing\`.