### PR TITLE
chore(helm): update chart to version 0.16.0 with appVersion 0.24.0

### DIFF
--- a/.github/workflows/lint-and-test.yaml
+++ b/.github/workflows/lint-and-test.yaml
@@ -26,7 +26,7 @@ jobs:
           python-version: 3.14
 
       - name: Run Trivy vulnerability scanner in IaC mode
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'config'
           hide-progress: false

--- a/charts/minecraft-exporter/Chart.yaml
+++ b/charts/minecraft-exporter/Chart.yaml
@@ -7,8 +7,8 @@ keywords:
   - prometheus
   - exporter
 type: application
-version: 0.15.0
-appVersion: 0.23.0
+version: 0.16.0
+appVersion: 0.24.0
 home: https://github.com/dirien/minecraft-prometheus-exporter/
 sources:
   - https://github.com/dirien/minecraft-prometheus-exporter/
@@ -19,10 +19,10 @@ maintainers:
 annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - update exporter to 0.23.0
+    - update exporter to 0.24.0
   artifacthub.io/images: |
     - name: minecraft-exporter
-      image: ghcr.io/dirien/minecraft-exporter:0.23.0
+      image: ghcr.io/dirien/minecraft-exporter:0.24.0
   artifacthub.io/license: Apache-2.0
   artifacthub.io/maintainers: |
     - name: dirien

--- a/charts/minecraft-exporter/README.md
+++ b/charts/minecraft-exporter/README.md
@@ -2,7 +2,7 @@
 
 ![minecraft-exporter](https://dirien.github.io/minecraft-prometheus-exporter/img/minecraft-exporter.jpg)
 
-![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.23.0](https://img.shields.io/badge/AppVersion-0.23.0-informational?style=flat-square)
+![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.0](https://img.shields.io/badge/AppVersion-0.24.0-informational?style=flat-square)
 
 ![Prometheus](https://img.shields.io/badge/Prometheus-E6522C?style=for-the-badge&logo=Prometheus&logoColor=white)
 ![Minecraft](https://img.shields.io/badge/Minecraft-62B47A?style=for-the-badge&logo=Minecraft&logoColor=white)
@@ -21,7 +21,7 @@ A Helm chart for prometheus minecraft exporter
 To install the chart using the OCI artifact, run:
 
 ```bash
-helm install minecraft-exporter oci://ghcr.io/dirien/charts/minecraft-exporter --version 0.15.0
+helm install minecraft-exporter oci://ghcr.io/dirien/charts/minecraft-exporter --version 0.16.0
 ```
 
 Keep in mind that you need Helm > 3.8.0 to use the [OCI feature](https://helm.sh/blog/storing-charts-in-oci/).
@@ -40,7 +40,7 @@ helm repo update
 To install the chart with the release name minecraft-exporter run:
 
 ```bash
-helm install minecraft-exporter minecraft-exporter/minecraft-exporter --version 0.15.0
+helm install minecraft-exporter minecraft-exporter/minecraft-exporter --version 0.16.0
 ```
 
 After a few seconds, minecraft-exporter should be running.
@@ -49,7 +49,7 @@ To install the chart in a specific namespace use following commands:
 
 ```bash
 kubectl create ns minecraft-exporter
-helm install minecraft-exporter minecraft-exporter/minecraft-exporter --namespace minecraft-exporter --version 0.15.0
+helm install minecraft-exporter minecraft-exporter/minecraft-exporter --namespace minecraft-exporter --version 0.16.0
 ```
 
 > **Tip**: List all releases using `helm list`, a release is a name used to track a specific deployment


### PR DESCRIPTION
## Summary

Bumps the Helm chart following the **v0.24.0** application release.

- Chart `version`: `0.15.0` → `0.16.0`
- Chart `appVersion`: `0.23.0` → `0.24.0`
- Updated Artifact Hub annotations (changes note + image tag `ghcr.io/dirien/minecraft-exporter:0.24.0`)
- Regenerated chart README version badges and `helm install --version` examples

## Release verification

The `v0.24.0` release completed successfully before this bump:
- GitHub release [`v0.24.0`](https://github.com/dirien/minecraft-prometheus-exporter/releases/tag/v0.24.0) published (30 assets)
- Multi-arch container image `ghcr.io/dirien/minecraft-exporter:0.24.0` published to GHCR (linux/amd64 + linux/arm64)

Signed-off-by: Engin Diri <engin.diri@ediri.de>